### PR TITLE
Feature/fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ This action scans the specified `paths` for project files and checks if their fi
 - **Description**: Specifies the format of the output report. Options include console, csv, and json.
 - **Required**: No
 - **Default**: `console`
+- **Options**:
+  - `console`: Prints the report to the console as a warning log message.
+  - `csv`: Generates a CSV file with the report. No output prints to the console. Path to the report file is provided in the `report-path` output.
+  - `json`: Generates a JSON file with the report. No output prints to the console. Path to the report file is provided in the `report-path` output.
 
 ### `verbose-logging`
 - **Description**: Enable verbose logging to provide detailed output during the action’s execution, aiding in troubleshooting and setup.
@@ -56,7 +60,7 @@ This action scans the specified `paths` for project files and checks if their fi
 - **Description**: Count of files not complying with the specified file name patterns.
 
 ### `report-path`
-- **Description**: Path to the generated report file.
+- **Description**: Path to the generated report file. **Not used** if the `report-format` is set to `console`.
 
 ## Usage Example
 ### Default

--- a/README.md
+++ b/README.md
@@ -36,26 +36,26 @@ This action scans the specified `paths` for project files and checks if their fi
 - **Required**: No
 - **Default**: ``
 
-### `report_format`
+### `report-format`
 - **Description**: Specifies the format of the output report. Options include console, csv, and json.
 - **Required**: No
 - **Default**: `console`
 
-### `verbose_logging`
+### `verbose-logging`
 - **Description**: Enable verbose logging to provide detailed output during the action’s execution, aiding in troubleshooting and setup.
 - **Required**: No
 - **Default**: `false`
 
-### `fail_on_violation`
+### `fail-on-violation`
 - **Description**: Set to true to fail the action if any convention violations are detected. Set false to continue without failure.
 - **Required**: No
 - **Default**: `false`
 
 ## Outputs
-### `violation_count`
+### `violation-count`
 - **Description**: Count of files not complying with the specified file name patterns.
 
-### `report_path`
+### `report-path`
 - **Description**: Path to the generated report file.
 
 ## Usage Example
@@ -72,7 +72,7 @@ jobs:
       id: scan-test-files
       uses: AbsaOSS/filename-inspector@v0.1.0
       with:
-        name_patterns: '*UnitTest.*,*IntegrationTest.*'
+        name-patterns: '*UnitTest.*,*IntegrationTest.*'
         paths: '**/src/test/java/**,**/src/test/scala/**'
 ```
 
@@ -90,12 +90,12 @@ jobs:
           id: scan-test-files
           uses: AbsaOSS/filename-inspector@v0.1.0
           with:
-            name_patterns: '*UnitTest.*,*IntegrationTest.*'
+            name-patterns: '*UnitTest.*,*IntegrationTest.*'
             paths: '**/src/test/java/**,**/src/test/scala/**'
             excludes: 'src/exclude_dir/*.py,tests/exclude_file.py'
-            report_format: 'console'
-            verbose_logging: 'false'
-            fail_on_violation: 'false'
+            report-format: 'console'
+            verbose-logging: 'false'
+            fail-on-violation: 'false'
 ```
 
 ## How to build

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The **Filename Inspector** GitHub Action is designed to ensure naming convention
 This action scans the specified `paths` for project files and checks if their file names fit the `name_patterns.` It reports the count of files not meeting the naming conventions, with options to fail the action if violations are found.
 
 ## Inputs
-### `name_patterns`
+### `name-patterns`
 - **Description**: List of file name [glob](https://en.wikipedia.org/wiki/Glob_(programming)) patterns that project files should have, separated by commas.
 - **Required**: Yes
 - **Example**: `*UnitTest.*,*IntegrationTest.*`
@@ -42,8 +42,8 @@ This action scans the specified `paths` for project files and checks if their fi
 - **Default**: `console`
 - **Options**:
   - `console`: Prints the list of violated files to the console.
-  - `csv`: Generates a CSV file with the report. No output prints to the console. Path to the report file is provided in the `report-path` output.
-  - `json`: Generates a JSON file with the report. No output prints to the console. Path to the report file is provided in the `report-path` output.
+  - `csv`: Generates a CSV file with the report. No printout of violated files to the console, unless verbose is enabled. Path to the report file is provided in the `report-path` output.
+  - `json`: Generates a JSON file with the report. No printout of violated files to the console, unless verbose is enabled. Path to the report file is provided in the `report-path` output.
 
 ### `verbose-logging`
 - **Description**: Enable verbose logging to provide detailed output during the action’s execution, aiding in troubleshooting and setup.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This action scans the specified `paths` for project files and checks if their fi
 - **Required**: No
 - **Default**: `console`
 - **Options**:
-  - `console`: Prints the report to the console as a warning log message.
+  - `console`: Prints the list of violated files to the console.
   - `csv`: Generates a CSV file with the report. No output prints to the console. Path to the report file is provided in the `report-path` output.
   - `json`: Generates a JSON file with the report. No output prints to the console. Path to the report file is provided in the `report-path` output.
 

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ outputs:
     description: 'Count of files that do not comply with the specified file name conventions.'
     value: ${{ steps.scan-test-files.outputs.violation_count }}
   report-path:
-    description: 'Path to the generated report file.'
+    description: "Path to the generated report file. Not used when 'console' is selected as the report format."
     value: ${{ steps.scan-test-files.outputs.report_path }}
 runs:
   using: 'composite'

--- a/src/filename_inspector.py
+++ b/src/filename_inspector.py
@@ -78,12 +78,10 @@ def run():
 
         set_action_output('violation-count', str(violation_count))
 
-        if verbose_logging:
-            print(f'Total violations: {violation_count}')
-            print(f'Violating files: {violations}')
+        logging.info(f'Total violations: {violation_count}')
+        logging.debug(f'Violating files: {violations}')
 
-        if report_format == 'console':
-            logging.info(f'Total violations: {violation_count}')
+        if report_format == 'console' and not verbose_logging:
             logging.info(f'Violating files: {violations}')
 
         if report_format == 'csv':

--- a/src/filename_inspector.py
+++ b/src/filename_inspector.py
@@ -79,11 +79,11 @@ def run():
             with open('violations.csv', mode='w', newline='') as file:
                 writer = csv.writer(file)
                 writer.writerows([[violation] for violation in violations])
-            set_output('report_path', 'violations.csv')
+            set_output('report-path', 'violations.csv')
         elif report_format == 'json':
             with open('violations.json', mode='w') as file:
                 json.dump({'violations': violations}, file)
-            set_output('report_path', 'violations.json')
+            set_output('report-path', 'violations.json')
 
         if fail_on_violation and violation_count > 0:
             set_failed(f'There are {violation_count} test file naming convention violations.')

--- a/src/filename_inspector.py
+++ b/src/filename_inspector.py
@@ -9,18 +9,25 @@ import csv
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 
-def get_input(name: str) -> str:
-    value = os.getenv(f'INPUT_{name.upper()}')
-    return value
+INPUT_NAME_PATTERNS = "INPUT_NAME_PATTERNS"
+INPUT_PATHS = "INPUT_PATHS"
+INPUT_EXCLUDES = "INPUT_EXCLUDES"
+INPUT_REPORT_FORMAT = "INPUT_REPORT_FORMAT"
+INPUT_VERBOSE_LOGGING = "INPUT_VERBOSE_LOGGING"
+INPUT_FAIL_ON_VIOLATION = "INPUT_FAIL_ON_VIOLATION"
 
 
-def set_output(name: str, value: str, default_output_path: str = "default_output.txt"):
+def get_action_input(name: str) -> str:
+    return os.getenv(name)
+
+
+def set_action_output(name: str, value: str, default_output_path: str = "default_output.txt"):
     output_file = os.getenv('GITHUB_OUTPUT', default_output_path)
     with open(output_file, 'a') as f:
         f.write(f'{name}={value}\n')
 
 
-def set_failed(message: str):
+def set_action_failed(message: str):
     logging.error(message)
     exit(1)
 
@@ -47,15 +54,15 @@ def find_non_matching_files(name_patterns, paths, excludes):
 
 def run():
     try:
-        name_patterns_raw = get_input('name_patterns')
+        name_patterns_raw = get_action_input(INPUT_NAME_PATTERNS)
         name_patterns = name_patterns_raw.split(',') if name_patterns_raw else []
-        paths_raw = get_input('paths')
+        paths_raw = get_action_input(INPUT_PATHS)
         paths = paths_raw.split(',')
-        excludes_raw = get_input('excludes')
+        excludes_raw = get_action_input(INPUT_EXCLUDES)
         excludes = excludes_raw.split(',')
-        report_format = get_input('report_format').lower()
-        verbose_logging = get_input('verbose_logging').lower() == 'true'
-        fail_on_violation = get_input('fail_on_violation').lower() == 'true'
+        report_format = get_action_input(INPUT_REPORT_FORMAT).lower()
+        verbose_logging = get_action_input(INPUT_VERBOSE_LOGGING).lower() == 'true'
+        fail_on_violation = get_action_input(INPUT_FAIL_ON_VIOLATION).lower() == 'true'
 
         if verbose_logging:
             logging.getLogger().setLevel(logging.DEBUG)
@@ -69,7 +76,7 @@ def run():
         violations = find_non_matching_files(name_patterns, paths, excludes)
         violation_count = len(violations)
 
-        set_output('violation-count', str(violation_count))
+        set_action_output('violation-count', str(violation_count))
 
         if verbose_logging:
             print(f'Total violations: {violation_count}')
@@ -83,29 +90,18 @@ def run():
             with open('violations.csv', mode='w', newline='') as file:
                 writer = csv.writer(file)
                 writer.writerows([[violation] for violation in violations])
-            set_output('report-path', 'violations.csv')
+            set_action_output('report-path', 'violations.csv')
         elif report_format == 'json':
             with open('violations.json', mode='w') as file:
                 json.dump({'violations': violations}, file)
-            set_output('report-path', 'violations.json')
+            set_action_output('report-path', 'violations.json')
 
         if fail_on_violation and violation_count > 0:
-            set_failed(f'There are {violation_count} test file naming convention violations.')
+            set_action_failed(f'There are {violation_count} test file naming convention violations.')
 
     except Exception as error:
         logging.error(f'Action failed with error: {error}')
-        set_failed(f'Action failed with error: {error}')
-
-# TODO
-# Inspector
-#   - report-path - ma ukazovat na spravny soubor a jeho cestu
-
-# RLS notes generator
-#   - set_output na set_action_output
-#   - set_failed na set_action_failed
-#   -
-#   -
-#   -
+        set_action_failed(f'Action failed with error: {error}')
 
 
 if __name__ == '__main__':

--- a/src/filename_inspector.py
+++ b/src/filename_inspector.py
@@ -71,9 +71,13 @@ def run():
 
         set_output('violation-count', str(violation_count))
 
-        if report_format == 'console' or verbose_logging:
-            logging.warning(f'Total violations: {violation_count}')
-            logging.warning(f'Violating files: {violations}')
+        if verbose_logging:
+            print(f'Total violations: {violation_count}')
+            print(f'Violating files: {violations}')
+
+        if report_format == 'console':
+            logging.info(f'Total violations: {violation_count}')
+            logging.info(f'Violating files: {violations}')
 
         if report_format == 'csv':
             with open('violations.csv', mode='w', newline='') as file:
@@ -91,6 +95,17 @@ def run():
     except Exception as error:
         logging.error(f'Action failed with error: {error}')
         set_failed(f'Action failed with error: {error}')
+
+# TODO
+# Inspector
+#   - report-path - ma ukazovat na spravny soubor a jeho cestu
+
+# RLS notes generator
+#   - set_output na set_action_output
+#   - set_failed na set_action_failed
+#   -
+#   -
+#   -
 
 
 if __name__ == '__main__':

--- a/src/filename_inspector.py
+++ b/src/filename_inspector.py
@@ -69,7 +69,7 @@ def run():
         violations = find_non_matching_files(name_patterns, paths, excludes)
         violation_count = len(violations)
 
-        set_output('violation_count', str(violation_count))
+        set_output('violation-count', str(violation_count))
 
         if report_format == 'console' or verbose_logging:
             logging.warning(f'Total violations: {violation_count}')

--- a/src/filename_inspector.py
+++ b/src/filename_inspector.py
@@ -79,9 +79,8 @@ def run():
         set_action_output('violation-count', str(violation_count))
 
         logging.info(f'Total violations: {violation_count}')
-        logging.debug(f'Violating files: {violations}')
 
-        if report_format == 'console' and not verbose_logging:
+        if report_format == 'console' or verbose_logging:
             logging.info(f'Violating files: {violations}')
 
         if report_format == 'csv':

--- a/tests/test_filename_inspector.py
+++ b/tests/test_filename_inspector.py
@@ -7,7 +7,7 @@ import pytest
 import os
 
 from unittest.mock import patch, mock_open
-from src.filename_inspector import get_input, set_output, set_failed, run
+from src.filename_inspector import get_action_input, set_action_output, set_action_failed, run
 
 # Constants
 DEFAULT_NAME_PATTERNS = '*UnitTest.*,*IntegrationTest.*'
@@ -68,7 +68,7 @@ def mock_set_failed(message):
 def test_set_output_env_var_set():
     with tempfile.NamedTemporaryFile() as tmpfile:
         with patch.dict(os.environ, {'GITHUB_OUTPUT': tmpfile.name}):
-            set_output('test_name', 'test_value')
+            set_action_output('test_name', 'test_value')
             tmpfile.seek(0)
             assert tmpfile.read().decode() == 'test_name=test_value\n'
 
@@ -78,7 +78,7 @@ def test_set_output_env_var_not_set():
         # Using mock_open with an in-memory stream to simulate file writing
         mock_file = mock_open()
         with patch('builtins.open', mock_file):
-            set_output('test_name', 'test_value')
+            set_action_output('test_name', 'test_value')
             mock_file().write.assert_called_with('test_name=test_value\n')
 
 
@@ -90,14 +90,14 @@ def test_set_output_env_var_not_set():
 def test_set_output_parametrized(name, value, expected):
     with tempfile.NamedTemporaryFile() as tmpfile:
         with patch.dict(os.environ, {'GITHUB_OUTPUT': tmpfile.name}):
-            set_output(name, value)
+            set_action_output(name, value)
             tmpfile.seek(0)
             assert tmpfile.read().decode() == expected
 
 
 def test_get_input(mock_getenv):
     with patch('os.getenv', return_value='test_value') as mock_getenv_func:
-        assert get_input('test') == 'test_value'
+        assert get_action_input('test') == 'test_value'
         mock_getenv_func.assert_called_with('INPUT_TEST')
 
 
@@ -108,7 +108,7 @@ def test_set_failed():
     with mock.patch('logging.error') as mock_log_error:
         # Test the SystemExit exception
         with pytest.raises(SystemExit) as pytest_wrapped_e:
-            set_failed(test_message)
+            set_action_failed(test_message)
         assert pytest_wrapped_e.type == SystemExit
         assert pytest_wrapped_e.value.code == 1
 

--- a/tests/test_filename_inspector.py
+++ b/tests/test_filename_inspector.py
@@ -141,9 +141,9 @@ def test_run(monkeypatch, paths, report_format, verbose_logging, excludes, fail_
     with (patch('src.filename_inspector.set_output', new=mock_set_output),
           patch('src.filename_inspector.set_failed', new=mock_set_failed)):
         run()
-        assert output_values['violation_count'] == str(expected_violation_count)
+        assert output_values['violation-count'] == str(expected_violation_count)
         if expected_report:
-            assert output_values['report_path'] == expected_report
+            assert output_values['report-path'] == expected_report
         if expected_failed_message:
             assert failed_message == expected_failed_message
 


### PR DESCRIPTION
- Fixed typo issue in README: `_` instead of `-`.
- Update the code to where it worked with `_` too.
- Updated unit tests.

Also closes #6 