### PR TITLE
#19. Log violated files with the warn level

### DIFF
--- a/src/filename_inspector.py
+++ b/src/filename_inspector.py
@@ -188,7 +188,7 @@ def run() -> None:
         logging.info("Total violations: %s", violation_count)
 
         if report_format == "console" or verbose_logging:
-            logging.info("Violating files: %s", violations)
+            logging.warning("Violating files: %s", violations)
 
         if report_format == "csv":
             with open("violations.csv", mode="w", newline="", encoding="utf-8") as file:


### PR DESCRIPTION
#19. Log violated files with the warn level.

Release Notes:
- Updated log messages for reporting violating files to use a warning level in certain cases, making them more noticeable to users.